### PR TITLE
Update framework, dependencies, and branding

### DIFF
--- a/Quasar.Client/ILRepack.targets
+++ b/Quasar.Client/ILRepack.targets
@@ -14,6 +14,7 @@
     Parallel="true"
     Internalize="true"
     InputAssemblies="@(InputAssemblies)"
+    LibraryPath="$(OutputPath)"
     TargetKind="SameAsPrimaryAssembly"
     OutputFile="$(TargetPath)"/>
   </Target>

--- a/Quasar.Client/IpGeoLocation/GeoInformationRetriever.cs
+++ b/Quasar.Client/IpGeoLocation/GeoInformationRetriever.cs
@@ -47,10 +47,13 @@ namespace Quasar.Client.IpGeoLocation
         /// <returns>The retrieved IP geolocation information.</returns>
         public GeoInformation Retrieve()
         {
+            /*
             var geo = TryRetrieveOnline() ?? TryRetrieveLocally();
 
             if (string.IsNullOrEmpty(geo.IpAddress))
                 geo.IpAddress = TryGetWanIp();
+            */
+            var geo = new GeoInformation();
 
             geo.IpAddress = (string.IsNullOrEmpty(geo.IpAddress)) ? "Unknown" : geo.IpAddress;
             geo.Country = (string.IsNullOrEmpty(geo.Country)) ? "Unknown" : geo.Country;

--- a/Quasar.Client/Quasar.Client.csproj
+++ b/Quasar.Client/Quasar.Client.csproj
@@ -65,7 +65,7 @@
     </PackageReference>
     <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
     <PackageReference Include="protobuf-net">
-      <Version>2.4.8</Version>
+      <Version>3.2.16</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/Quasar.Client/Quasar.Client.csproj
+++ b/Quasar.Client/Quasar.Client.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <OutputType>WinExe</OutputType>
     <AssemblyName>Client</AssemblyName>
     <UseWindowsForms>true</UseWindowsForms>

--- a/Quasar.Common.Tests/Quasar.Common.Tests.csproj
+++ b/Quasar.Common.Tests/Quasar.Common.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Quasar.Common.Tests/Quasar.Common.Tests.csproj
+++ b/Quasar.Common.Tests/Quasar.Common.Tests.csproj
@@ -12,9 +12,9 @@
     <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Quasar.Common\Quasar.Common.csproj" />

--- a/Quasar.Common/Quasar.Common.csproj
+++ b/Quasar.Common/Quasar.Common.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="protobuf-net">
-      <Version>2.4.8</Version>
+      <Version>3.2.16</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/Quasar.Common/Quasar.Common.csproj
+++ b/Quasar.Common/Quasar.Common.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net48</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/Quasar.Server/Quasar.Server.csproj
+++ b/Quasar.Server/Quasar.Server.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <OutputType>WinExe</OutputType>
     <AssemblyName>Quasar</AssemblyName>
     <UseWindowsForms>true</UseWindowsForms>

--- a/Quasar.Server/Quasar.Server.csproj
+++ b/Quasar.Server/Quasar.Server.csproj
@@ -309,7 +309,7 @@
     <PackageReference Include="Open.Nat" Version="2.1.0" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
     <PackageReference Include="protobuf-net">
-      <Version>2.4.8</Version>
+      <Version>3.2.16</Version>
     </PackageReference>
     <PackageReference Include="Vestris.ResourceLib">
       <Version>2.1.0</Version>

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Quasar
+# Hitsuji
 
-[![Build status](https://ci.appveyor.com/api/projects/status/5857hfy6r1ltb5f2?svg=true)](https://ci.appveyor.com/project/MaxXor/quasar)
-[![Downloads](https://img.shields.io/github/downloads/quasar/Quasar/total.svg)](https://github.com/quasar/Quasar/releases)
-[![License](https://img.shields.io/github/license/quasar/Quasar.svg)](LICENSE)
+[![Downloads](https://img.shields.io/github/downloads/Avlyssna/Hitsuji/total.svg)](https://github.com/Avlyssna/Hitsuji/releases)
+[![License](https://img.shields.io/github/license/Avlyssna/Hitsuji.svg)](LICENSE)
 
 **Free, Open-Source Remote Administration Tool for Windows**
 
-Quasar is a fast and light-weight remote administration tool coded in C#. The usage ranges from user support through day-to-day administrative work to employee monitoring. Providing high stability and an easy-to-use user interface, Quasar is the perfect remote administration solution for you.
+Hitsuji is a fork of the popular [Quasar](https://github.com/quasar/Quasar) tool.
+It is designed for use as a red-team persistence tool during penetration testing.
 
 ## Screenshots
 
@@ -36,44 +36,20 @@ Quasar is a fast and light-weight remote administration tool coded in C#. The us
 * ... and many more!
 
 ## Download
-* [Latest stable release](https://github.com/quasar/Quasar/releases) (recommended)
-* [Latest development snapshot](https://ci.appveyor.com/project/MaxXor/quasar)
-
-## Supported runtimes and operating systems
-* .NET Framework 4.5.2 or higher
-* Supported operating systems (32- and 64-bit)
-  * Windows 11
-  * Windows Server 2022
-  * Windows 10
-  * Windows Server 2019
-  * Windows Server 2016
-  * Windows 8/8.1
-  * Windows Server 2012
-  * Windows 7
-  * Windows Server 2008 R2
-* For older systems please use [Quasar version 1.3.0](https://github.com/quasar/Quasar/releases/tag/v1.3.0.0)
-
-## Compiling
-Open the project `Quasar.sln` in Visual Studio 2019+ with installed .NET desktop development features and [restore the NuGET packages](https://docs.microsoft.com/en-us/nuget/consume-packages/package-restore). Once all packages are installed the project can be compiled as usual by clicking `Build` at the top or by pressing `F6`. The resulting executables can be found in the `Bin` directory. See below which build configuration to choose from.
+* [Latest stable release](https://github.com/Avlyssna/Hitsuji/releases) (recommended)
 
 ## Building a client
 | Build configuration         | Usage scenario | Description
 | ----------------------------|----------------|--------------
-| Debug configuration         | Testing        | The pre-defined [Settings.cs](/Quasar.Client/Config/Settings.cs) will be used, so edit this file before compiling the client. You can execute the client directly with the specified settings.
-| Release configuration       | Production     | Start `Quasar.exe` and use the client builder.
+| Debug configuration         | Testing        | The pre-defined [Settings.cs](/Hitsuji.Client/Config/Settings.cs) will be used, so edit this file before compiling the client. You can execute the client directly with the specified settings.
+| Release configuration       | Production     | Start `Hitsuji.exe` and use the client builder.
 
 ## Contributing
 See [CONTRIBUTING.md](CONTRIBUTING.md)
 
-## Roadmap
-See [ROADMAP.md](ROADMAP.md)
-
 ## Documentation
-See the [wiki](https://github.com/quasar/Quasar/wiki) for usage instructions and other documentation.
+See the [wiki](https://github.com/Avlyssna/Hitsuji/wiki) for usage instructions and other documentation.
 
 ## License
-Quasar is distributed under the [MIT License](LICENSE).  
+Hitsuji is distributed under the [MIT License](LICENSE).
 Third-party licenses are located [here](Licenses).
-
-## Thank you!
-I really appreciate all kinds of feedback and contributions. Thanks for using and supporting Quasar!


### PR DESCRIPTION
This pull request:

- Updates the .NET framework to 4.8
- Updates all dependencies to their latest release
- Updates some (not all) branding from Quasar to Hitsuji
- Hot-fixes for the geographic IP detection vector